### PR TITLE
Minor fix for midiproc

### DIFF
--- a/compat/os_compat.h
+++ b/compat/os_compat.h
@@ -16,7 +16,11 @@
 #include <wchar.h>
 
 #ifndef MAX_PATH
+#ifdef PATH_MAX
 #define MAX_PATH PATH_MAX
+#else
+#define MAX_PATH 256
+#endif
 #endif
 
 #ifndef WCHAR


### PR DESCRIPTION
I've been porting to various consoles and on some targets PATH_MAX isn't defined.
I've done a check for this.